### PR TITLE
feat: finalização de pedido com cupom e produtos comprados

### DIFF
--- a/src/main/java/com/example/price_wise_fullstack/controller/OrderController.java
+++ b/src/main/java/com/example/price_wise_fullstack/controller/OrderController.java
@@ -1,0 +1,24 @@
+package com.example.price_wise_fullstack.controller;
+
+import com.example.price_wise_fullstack.dto.OrderRequestDTO;
+import com.example.price_wise_fullstack.dto.OrderSummaryDTO;
+import com.example.price_wise_fullstack.service.OrderService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    @Autowired
+    private OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<OrderSummaryDTO> createOrder(@Valid @RequestBody OrderRequestDTO dto) {
+        OrderSummaryDTO result = orderService.saveOrder(dto);
+        return ResponseEntity.ok(result);
+    }
+}
+

--- a/src/main/java/com/example/price_wise_fullstack/dto/OrderRequestDTO.java
+++ b/src/main/java/com/example/price_wise_fullstack/dto/OrderRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.price_wise_fullstack.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Data
+public class OrderRequestDTO {
+    @NotEmpty
+    private List<Long> productIds;
+
+    @NotBlank
+    private String couponCode;
+
+}
+

--- a/src/main/java/com/example/price_wise_fullstack/dto/OrderSummaryDTO.java
+++ b/src/main/java/com/example/price_wise_fullstack/dto/OrderSummaryDTO.java
@@ -1,0 +1,20 @@
+package com.example.price_wise_fullstack.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class OrderSummaryDTO {
+    private Long orderId;
+    private List<String> productNames;
+    private BigDecimal totalOriginal;
+    private BigDecimal discountApplied;
+    private BigDecimal totalFinal;
+    private String couponCode;
+    private LocalDateTime createdAt;
+
+}
+

--- a/src/main/java/com/example/price_wise_fullstack/model/Order.java
+++ b/src/main/java/com/example/price_wise_fullstack/model/Order.java
@@ -1,0 +1,46 @@
+package com.example.price_wise_fullstack.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Table(name = "orders")
+@Data
+public class Order {
+    @Id 
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private BigDecimal totalOriginal;
+    private BigDecimal discountApplied;
+    private BigDecimal totalFinal;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    private Coupon coupon;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> items = new ArrayList<>();
+
+    @PrePersist
+    public void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/example/price_wise_fullstack/model/OrderItem.java
+++ b/src/main/java/com/example/price_wise_fullstack/model/OrderItem.java
@@ -1,0 +1,28 @@
+package com.example.price_wise_fullstack.model;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Table(name = "order_items")
+@Data
+public class OrderItem {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Order order;
+
+    @ManyToOne
+    private Product product;
+
+    private BigDecimal price;
+
+}

--- a/src/main/java/com/example/price_wise_fullstack/repository/OrderRepository.java
+++ b/src/main/java/com/example/price_wise_fullstack/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.example.price_wise_fullstack.repository;
+
+import com.example.price_wise_fullstack.model.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}
+

--- a/src/main/java/com/example/price_wise_fullstack/service/OrderService.java
+++ b/src/main/java/com/example/price_wise_fullstack/service/OrderService.java
@@ -1,0 +1,85 @@
+package com.example.price_wise_fullstack.service;
+
+import com.example.price_wise_fullstack.dto.OrderRequestDTO;
+import com.example.price_wise_fullstack.dto.OrderSummaryDTO;
+import com.example.price_wise_fullstack.model.Coupon;
+import com.example.price_wise_fullstack.model.Order;
+import com.example.price_wise_fullstack.model.OrderItem;
+import com.example.price_wise_fullstack.model.Product;
+import com.example.price_wise_fullstack.repository.CouponRepository;
+import com.example.price_wise_fullstack.repository.OrderRepository;
+import com.example.price_wise_fullstack.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class OrderService {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    public OrderSummaryDTO saveOrder(OrderRequestDTO dto) {
+        List<Product> products = productRepository.findAllById(dto.getProductIds());
+        if (products.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Produtos não encontrados");
+        }
+
+        Coupon coupon = couponRepository.findByCodeIgnoreCase(dto.getCouponCode().trim().toLowerCase())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Cupom não encontrado"));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (coupon.getDeletedAt() != null || now.isBefore(coupon.getValidFrom()) || now.isAfter(coupon.getValidUntil())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cupom expirado ou inválido");
+        }
+
+        BigDecimal totalOriginal = products.stream()
+                .map(Product::getPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal discount = coupon.getType().equals("percent")
+                ? totalOriginal.multiply(coupon.getDiscountValue()).divide(BigDecimal.valueOf(100))
+                : coupon.getDiscountValue();
+
+        BigDecimal totalFinal = totalOriginal.subtract(discount).max(BigDecimal.ZERO);
+
+        Order order = new Order();
+        order.setCoupon(coupon);
+        order.setTotalOriginal(totalOriginal);
+        order.setDiscountApplied(discount);
+        order.setTotalFinal(totalFinal);
+
+        for (Product product : products) {
+            OrderItem item = new OrderItem();
+            item.setOrder(order);
+            item.setProduct(product);
+            item.setPrice(product.getPrice());
+            order.getItems().add(item);
+        }
+
+        Order saved = orderRepository.save(order);
+
+        OrderSummaryDTO summary = new OrderSummaryDTO();
+        summary.setOrderId(saved.getId());
+        summary.setProductNames(products.stream().map(Product::getName).toList());
+        summary.setTotalOriginal(totalOriginal);
+        summary.setDiscountApplied(discount);
+        summary.setTotalFinal(totalFinal);
+        summary.setCouponCode(coupon.getCode());
+        summary.setCreatedAt(saved.getCreatedAt());
+
+        return summary;
+    }
+}
+


### PR DESCRIPTION
Este PR implementa a criação e persistência de pedidos após o fluxo de checkout do carrinho, relacionando produtos e cupons promocionais.

### ✅ Funcionalidades:
- Endpoint `POST /api/v1/orders` para finalizar compra
- Valida produtos e cupom enviados
- Calcula totais: original, desconto e final
- Cria `Order` e `OrderItem` com valores e relacionamentos
- Persiste a data de criação e aplica cupom ao pedido
- Retorna resumo com `OrderSummaryDTO`

### 🧠 Lógica de negócio:
- Validação de cupom expirado ou deletado
- Cupom `fixed` ou `percent` aplicado ao total
- Evita valores negativos com `.max(BigDecimal.ZERO)`
- Associação de produtos ao pedido via `OrderItem`

### 📘 Tecnologias:
- Spring Boot com JPA, DTOs e Bean Validation
- Camada de serviço desacoplada
- Pronto para histórico e listagem de pedidos futuros