### PR TITLE
feat: listagem de pedidos com resumo de produtos e cupom aplicado

### DIFF
--- a/src/main/java/com/example/price_wise_fullstack/controller/OrderController.java
+++ b/src/main/java/com/example/price_wise_fullstack/controller/OrderController.java
@@ -4,6 +4,9 @@ import com.example.price_wise_fullstack.dto.OrderRequestDTO;
 import com.example.price_wise_fullstack.dto.OrderSummaryDTO;
 import com.example.price_wise_fullstack.service.OrderService;
 import jakarta.validation.Valid;
+
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +22,12 @@ public class OrderController {
     public ResponseEntity<OrderSummaryDTO> createOrder(@Valid @RequestBody OrderRequestDTO dto) {
         OrderSummaryDTO result = orderService.saveOrder(dto);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<OrderSummaryDTO>> listOrders() {
+        List<OrderSummaryDTO> list = orderService.listAllOrders();
+        return ResponseEntity.ok(list);
     }
 }
 

--- a/src/main/java/com/example/price_wise_fullstack/service/OrderService.java
+++ b/src/main/java/com/example/price_wise_fullstack/service/OrderService.java
@@ -81,5 +81,22 @@ public class OrderService {
 
         return summary;
     }
+
+    public List<OrderSummaryDTO> listAllOrders() {
+        List<Order> orders = orderRepository.findAll();
+
+        return orders.stream().map(order -> {
+            OrderSummaryDTO dto = new OrderSummaryDTO();
+            dto.setOrderId(order.getId());
+            dto.setCouponCode(order.getCoupon() != null ? order.getCoupon().getCode() : null);
+            dto.setCreatedAt(order.getCreatedAt());
+            dto.setTotalOriginal(order.getTotalOriginal());
+            dto.setDiscountApplied(order.getDiscountApplied());
+            dto.setTotalFinal(order.getTotalFinal());
+            dto.setProductNames(order.getItems().stream()
+                .map(item -> item.getProduct().getName()).toList());
+            return dto;
+        }).toList();
+    }
 }
 


### PR DESCRIPTION
Este PR adiciona o endpoint `GET /api/v1/orders` à API, permitindo a listagem de todos os pedidos realizados, com informações detalhadas sobre produtos comprados, valores e cupons aplicados.

### ✅ Funcionalidades:
- Novo método `listAllOrders()` no `OrderService`
- Mapeamento de `Order` para `OrderSummaryDTO`
- Retorno de:
  - `orderId`
  - `productNames`
  - `totalOriginal`
  - `discountApplied`
  - `totalFinal`
  - `couponCode`
  - `createdAt`
- Novo endpoint REST no `OrderController`

### 📘 Tecnologias:
- Spring Boot com Stream API
- Conversão de entidades para DTO com Java 17+
- Controller REST seguindo convenção RESTful

### 🧪 Testado com:
- Tunder Client (`GET /api/v1/orders`)
- Pedido criado previamente com cupom válido e múltiplos produtos